### PR TITLE
Add restricted telegram bot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ By default Windows doesn't display the notifications in the notification center.
 6. Press `BEGIN`.
 7. Your bot should greet you, and show a notification about your favorites. Note: the bot will show the favorites which you configured. Multiple people can connect to the bot to get updates about these favorites.
 
+It's possible to setup the bot in restricted mode so only the allowed telegram chat ids will be able to use the bot to subscribe for notifications.
+
 ## Configure IFTTT integration
 
 1. Go to [https://ifttt.com/create/](https://ifttt.com/create/).
@@ -66,9 +68,11 @@ By default Windows doesn't display the notifications in the notification center.
 Note: You can add multiple events to `webhookEvents`
 
 ## Docker
+
 Note: the Docker image is a multiarch image. So it will also work on Raspberry Pi's.
 
 ### Docker run
+
 1. Create a directory to store the config file and copy the [config.defaults.json](https://github.com/marklagendijk/node-toogoodtogo-watcher/blob/master/config.defaults.json) into `YOUR_FOLDER/config.json`. See above for instructions on how to configure the application. Make sure that the folder has the correct permissions, e.g. run chmod -R o+rwx config/ or you might get access denied errors on the file system. The app needs read/write access on the configuration file, e.g. to store token received in it.
 2. Run the following command. Example: a user `john` who stored the config in `~/docker/toogoodtogo-watcher/config.json`:
 
@@ -86,6 +90,7 @@ and use "--network=gotify" on both containers
 You can then use "http://gotify" on this container if --name gotify is used for the gotify container
 
 ### Docker Compose
+
 1. Create a directory to contain all your Docker Compose things.
 2. Create a directory `toogoodtogo-watcher` inside the created directory, and copy the [config.defaults.json](https://github.com/marklagendijk/node-toogoodtogo-watcher/blob/master/config.defaults.json) to `toogoodtogo-watcher/config.json`. See above for instructions on how to configure the application.
 3. Create a file `docker-compose.yaml`:
@@ -105,4 +110,4 @@ services:
 ## Running with Heroku
 
 1. Install the Heroku CLI and login.
-2. From your terminal, run ```heroku config:set TOOGOODTOGO_CONFIG=content```, replacing content with the content of your config.json file.
+2. From your terminal, run `heroku config:set TOOGOODTOGO_CONFIG=content`, replacing content with the content of your config.json file.

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -22,7 +22,9 @@
     "telegram": {
       "enabled": false,
       "botToken": "See README",
-      "chats": []
+      "chats": [],
+      "restricted": false,
+      "allowedChatIDs": []
     },
     "ifttt": {
       "enabled": false,

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -61,7 +61,7 @@ function notify(message) {
   const allowedChats = getAllowedChats();
   _.forEach(
     chats,
-    (chat) => allowedChats.includes(chat.id) && sendMessage(chat.id, message)
+    (chat) => allowedChats.has(chat.id) && sendMessage(chat.id, message)
   );
 }
 
@@ -102,7 +102,7 @@ function startCommand(context) {
   if (isRestricted()) {
     if (getNumberOfAllowedChats() == 0 && getNumberOfActiveChats() == 0) {
       addAllowedChat(context.chat.id);
-    } else if (!getAllowedChats().includes(context.chat.id)) {
+    } else if (!getAllowedChats().has(context.chat.id)) {
       context.reply(`👋 I am the TooGoodToGo bot.
 			I'm sorry but this bot is running in restriced mode and this Telegram account isn't allowed.`);
     }
@@ -270,10 +270,10 @@ function getNumberOfActiveChats() {
 }
 
 function getAllowedChats() {
-  return config.get("notifications.telegram.allowedChatIDs") || [];
+  return Set(config.get("notifications.telegram.allowedChatIDs") || []);
 }
 
 function getNumberOfAllowedChats() {
-  const chats = config.get("notifications.telegram.allowedChatIDs");
+  const chats = getAllowedChats();
   return _.size(chats);
 }

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -9,6 +9,10 @@ const cache = {};
 const bot = createBot();
 const botCommands = [
   {
+    command: "add_allowed_ids",
+    description: "Add allowed chat ids",
+  },
+  {
     command: "show_unchanged",
     description: "Activate alert for unchanged stock.",
   },
@@ -89,6 +93,7 @@ function createBot() {
   bot.command("start", startCommand);
   bot.command("stop", stopCommand);
   bot.command("config", configCommand);
+  bot.command("add_allowed_ids", addAllowedChatCommand);
   bot.command("show_unchanged", showUnchangedCommand);
   bot.command("show_decrease", showDecreaseCommand);
   bot.command("show_decrease_to_zero", showDecreaseToZeroCommand);
@@ -101,9 +106,9 @@ function createBot() {
 function startCommand(context) {
   if (isRestricted()) {
     if (getNumberOfAllowedChats() == 0 && getNumberOfActiveChats() == 0) {
-      addAllowedChat(context.chat.id);
-    } else if (!getAllowedChats().has(context.chat.id)) {
-      context.reply(`👋 I am the TooGoodToGo bot.
+      addAllowedChats(context.message.from.id);
+    } else if (!getAllowedChats().has(context.message.from.id)) {
+      return context.reply(`👋 I am the TooGoodToGo bot.
 			I'm sorry but this bot is running in restriced mode and this Telegram account isn't allowed.`);
     }
   }
@@ -115,7 +120,7 @@ function startCommand(context) {
       `👋 I am the TooGoodToGo bot.
 🚨 I will tell you whenever the stock of your favorites changes.
 If you get tired of my spamming you can (temporarily) disable me with:
-	/stop`
+/stop`
     )
     .then(() => {
       if (cache.message) {
@@ -127,7 +132,7 @@ If you get tired of my spamming you can (temporarily) disable me with:
 function stopCommand(context) {
   context.reply(`😐 Ok.. I get it. Too much is too much. I'll stop bothering you now. 🤫.
 You can enable me again with:
-	/start`);
+/start`);
   removeChat(context.chat.id);
 }
 
@@ -135,6 +140,7 @@ function configCommand(context) {
   const config = getConfig();
   context.reply(`🔧 Of course !
 Enabled : ${config.bot ? "✅" : "🚫"}
+Restricted : ${isRestricted() ? "✅" : "🚫"}
 Activate alert for unchanged stock : ${
     config.messageFilter.showUnchanged ? "✅" : "🚫"
   }
@@ -151,6 +157,53 @@ Activate alert for new market available : ${
     config.messageFilter.showIncreaseFromZero ? "✅" : "🚫"
   }
   `);
+}
+
+function addAllowedChatCommand(context) {
+  if (!isRestricted()) {
+    return context.reply("This command only works in restricted mode");
+  } else if (!getAllowedChats().has(context.message.from.id)) {
+    return context.reply(`Command restricted to allowed chats`);
+  }
+  let ids = context.update.message.text.split(" ").slice(1);
+  if (ids.length === 0) {
+    return context.reply(`Usage /add_allowed_ids [<ID1> <ID2> ...]`);
+  }
+  let promises = [];
+  ids.forEach((id) => {
+    promises.push(
+      new Promise((resolve, reject) => {
+        context.tg
+          .getChat(id)
+          .then(resolve)
+          .catch(() => reject(id));
+      })
+    );
+  });
+  Promise.allSettled(promises).then((data) => {
+    let resolved = [];
+    let rejected = [];
+    data.forEach((item) => {
+      if (item.status === "fulfilled") {
+        resolved.push(item.value.id);
+      } else if (item.status === "rejected") {
+        rejected.push(item.reason);
+      }
+    });
+    let msg = [];
+    if (resolved.length > 0) {
+      addAllowedChats(resolved);
+      msg.push(`Succesfully allowed IDs ${resolved.join(",")}`);
+    }
+    if (rejected.length > 0) {
+      msg.push(
+        `Some IDs (${rejected.join(
+          ","
+        )}) couldn't be added. Make sure they are valid Telegram IDs and that the user has already started a conversation with me.`
+      );
+    }
+    context.reply(msg.join("\n"));
+  });
 }
 
 function showUnchangedCommand(context) {
@@ -218,8 +271,12 @@ function addChat(context) {
   emitNumberOfActiveChats();
 }
 
-function addAllowedChat(chatId) {
-  config.set("notifications.telegram.allowedChatIDs", [chatId]);
+function addAllowedChats(args) {
+  let chats = getAllowedChats();
+  let newChats = [].concat(args || []);
+  console.log(`Allowed chats ${newChats.join(",")}`);
+  newChats.forEach((id) => chats.add(id));
+  config.set("notifications.telegram.allowedChatIDs", [...chats]);
 }
 
 function removeChat(chatId) {

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -270,7 +270,7 @@ function getNumberOfActiveChats() {
 }
 
 function getAllowedChats() {
-  return Set(config.get("notifications.telegram.allowedChatIDs") || []);
+  return new Set(config.get("notifications.telegram.allowedChatIDs") || []);
 }
 
 function getNumberOfAllowedChats() {

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -58,7 +58,11 @@ function notify(message) {
   cache.message = message;
 
   const chats = getChats();
-  _.forEach(chats, (chat) => sendMessage(chat.id, message));
+  const allowedChats = getAllowedChats();
+  _.forEach(
+    chats,
+    (chat) => allowedChats.includes(chat.id) && sendMessage(chat.id, message)
+  );
 }
 
 function sendMessage(chatId, message) {
@@ -95,6 +99,15 @@ function createBot() {
 }
 
 function startCommand(context) {
+  if (isRestricted()) {
+    if (getNumberOfAllowedChats() == 0 && getNumberOfActiveChats() == 0) {
+      addAllowedChat(context.chat.id);
+    } else if (!getAllowedChats().includes(context.chat.id)) {
+      context.reply(`👋 I am the TooGoodToGo bot.
+			I'm sorry but this bot is running in restriced mode and this Telegram account isn't allowed.`);
+    }
+  }
+
   addChat(context);
   context.telegram.setMyCommands(botCommands);
   context
@@ -102,7 +115,7 @@ function startCommand(context) {
       `👋 I am the TooGoodToGo bot.
 🚨 I will tell you whenever the stock of your favorites changes.
 If you get tired of my spamming you can (temporarily) disable me with:
-/stop`
+	/stop`
     )
     .then(() => {
       if (cache.message) {
@@ -114,7 +127,7 @@ If you get tired of my spamming you can (temporarily) disable me with:
 function stopCommand(context) {
   context.reply(`😐 Ok.. I get it. Too much is too much. I'll stop bothering you now. 🤫.
 You can enable me again with:
-/start`);
+	/start`);
   removeChat(context.chat.id);
 }
 
@@ -205,6 +218,10 @@ function addChat(context) {
   emitNumberOfActiveChats();
 }
 
+function addAllowedChat(chatId) {
+  config.set("notifications.telegram.allowedChatIDs", [chatId]);
+}
+
 function removeChat(chatId) {
   const chats = getChats();
   const chat = _.find(chats, { id: chatId });
@@ -235,6 +252,10 @@ function isEnabled() {
   return !!config.get("notifications.telegram.enabled");
 }
 
+function isRestricted() {
+  return !!config.get("notifications.telegram.restricted");
+}
+
 function getChats() {
   return config.get("notifications.telegram.chats");
 }
@@ -245,5 +266,14 @@ function getBotToken() {
 
 function getNumberOfActiveChats() {
   const chats = config.get("notifications.telegram.chats");
+  return _.size(chats);
+}
+
+function getAllowedChats() {
+  return config.get("notifications.telegram.allowedChatIDs") || [];
+}
+
+function getNumberOfAllowedChats() {
+  const chats = config.get("notifications.telegram.allowedChatIDs");
   return _.size(chats);
 }


### PR DESCRIPTION
Although it's very unlikely to have people eavesdrop on your favourites and take advantage of your notifications, might be interesting for some people to restrict bot usage to only some allowed chats.

PS: Added a default behaviour to allow the first person starting it when restricted mode is enabled and both the allowed and the chat list are empty.