### PR TITLE
IFTTT fix endpoint

### DIFF
--- a/lib/ifttt.js
+++ b/lib/ifttt.js
@@ -13,7 +13,7 @@ function notifyIFTTT(textMessage, htmlMessage) {
   const iftttEvents = config.get("notifications.ifttt.webhookEvents");
   for (const iftttEvent of iftttEvents) {
     api.post(
-      `${iftttEvent}/with/key/${config.get("notifications.ifttt.webhookKey")}`,
+      `${iftttEvent}/json/with/key/${config.get("notifications.ifttt.webhookKey")}`,
       {
         json: {
           value1: textMessage,


### PR DESCRIPTION
Fix IFTTT endpoint to attach json payload.
The Previous version sends the event but the endpoint does not accept the payload:
https://help.ifttt.com/hc/en-us/articles/4405029291163-Parsing-JSON-body-with-filter-code