### PR TITLE
Fix for 403 errors on refresh

### DIFF
--- a/lib/toogoodtogo-api.js
+++ b/lib/toogoodtogo-api.js
@@ -9,8 +9,8 @@ const api = got.extend({
   headers: _.defaults(config.get("api.headers"), {
     "User-Agent":
       "TooGoodToGo/21.9.0 (813) (iPhone/iPhone 7 (GSM); iOS 15.1; Scale/2.00)",
-    "Content-Type": "application/json",
-    Accept: "",
+    "Content-Type": "application/json; charset=utf-8",
+    Accept: "application/json",
     "Accept-Language": "en-US",
     "Accept-Encoding": "gzip",
   }),


### PR DESCRIPTION
When I started getting 403 errors on refresh requests, around the end of January, I made this change based on ahivert/tgtg-python@eec42aa84f686aaa3c19146f1bdd5271e5fa1d71. I haven't had problems since. So this is a possible fix for #212. I haven't tried upgrading to the 4.x releases though.