### PR TITLE
Remove userId from API calls

### DIFF
--- a/lib/toogoodtogo-api.js
+++ b/lib/toogoodtogo-api.js
@@ -78,7 +78,6 @@ export function listFavoriteBusinesses() {
         longitude: 13.3888599,
       },
       radius: 200,
-      user_id: session.userId,
     },
     headers: {
       Authorization: `Bearer ${session.accessToken}`,
@@ -93,7 +92,6 @@ function getSession() {
 function createSession(login) {
   if (login) {
     config.set("api.session", {
-      userId: login.startup_data.user.user_id,
       accessToken: login.access_token,
       refreshToken: login.refresh_token,
     });


### PR DESCRIPTION
Since the latest update the userId is no longer a part of the return object when logging in and the application throws an exception during login. The userId is also no longer necessary for listFavoriteBusinesses. To make login work again, I'm proposing the removal of the userId from the API calls.