### PR TITLE
feat: Automatically fetch latest tgtg version on startup

### DIFF
--- a/lib/toogoodtogo-api.js
+++ b/lib/toogoodtogo-api.js
@@ -4,12 +4,16 @@ import got from "got";
 import { CookieJar } from "tough-cookie";
 import { config } from "./config.js";
 
+let tgtgVersion = "25.4.1";
+
+await refreshLatestTgtgVersion();
+
 const api = got.extend({
   cookieJar: new CookieJar(),
   prefixUrl: "https://apptoogoodtogo.com/api/",
   headers: _.defaults(config.get("api.headers"), {
     "User-Agent":
-      "TGTG/25.4.1 Dalvik/2.1.0 (Linux; Android 12; SM-G920V Build/MMB29K)",
+      `TGTG/${tgtgVersion} Dalvik/2.1.0 (Linux; Android 12; SM-G920V Build/MMB29K)`,
     "Content-Type": "application/json; charset=utf-8",
     Accept: "application/json",
     "Accept-Language": "en-US",
@@ -110,4 +114,31 @@ function createSession(login) {
 function updateSession(token) {
   config.set("api.session.accessToken", token.access_token);
   return token;
+}
+
+async function refreshLatestTgtgVersion() {
+  try {
+    const gplayResponse = await got.get("https://play.google.com/store/apps/details?id=com.app.tgtg", {
+      resolveBodyOnly: true
+    })
+    const candidateVersions = [];
+    const matchesInitDataCallback = gplayResponse.matchAll(
+      /<script class=\"\S+\" nonce=\"\S+\">AF_initDataCallback\((.*?)\);/g,
+    );
+    for (const match of matchesInitDataCallback) {
+      const matchesVersion = match[1].matchAll(/(\d+\.\d+\.\d+)/g);
+      for (const match of matchesVersion) {
+        candidateVersions.push(match[1])
+      }
+    }
+    tgtgVersion = candidateVersions.reduce((a, b) =>
+      0 < a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+        ? a
+        : b
+    )
+  } catch (error) {
+    console.log(
+      `Error while retrieving latest version of TGTG on Google Play page: \n${error}`
+    )
+  }
 }


### PR DESCRIPTION
This new code change reduces the likeliness of getting 403 errors messages by always sending the latest tgtg app version. It is now known that datadome, the protection of tgtg, will return a 403 if the app version is too old (https://github.com/marklagendijk/node-toogoodtogo-watcher/pull/251).

I found a simple way to get the latest version using the Google play page. The code is based on this finding: https://stackoverflow.com/a/73331850

It's actually pretty simple:
1. Fetch the Google play page for TGTG
2. Discard everything in the HTML source code except text that match `/<script nonce=\"\S+\">AF_initDataCallback\((.*?)\);/g`.
3. Find all the version number (X.X.X) using this regex: `/(\d+\.\d+\.\d+)/g` and put all the versions found in an array.
4. Filter the array by only getting the highest version number. Solution found in https://stackoverflow.com/a/58027214

This should be fail proof for quite some time because this doesn't rely on a specific JSON ID like the stackoverflow code linked above. And if the code doesn't work in the future, then the program will always fallback to the fixed version number set in the 6th line (tgtgVersion).

Fixes #245