### PR TITLE
Changed auth endpoint from "auth/v4/token/refresh" to "token/v1/refresh"

### DIFF
--- a/lib/toogoodtogo-api.js
+++ b/lib/toogoodtogo-api.js
@@ -59,7 +59,7 @@ function refreshToken() {
   const session = getSession();
 
   return api
-    .post("auth/v4/token/refresh", {
+    .post("token/v1/refresh", {
       json: {
         refresh_token: session.refreshToken,
       },


### PR DESCRIPTION
As described in #258 (https://github.com/marklagendijk/node-toogoodtogo-watcher/issues/258#issuecomment-2689901893)