### PR TITLE
Added x-correlation-id header

### DIFF
--- a/lib/toogoodtogo-api.js
+++ b/lib/toogoodtogo-api.js
@@ -2,6 +2,7 @@ import _ from "lodash";
 import got from "got";
 import { CookieJar } from "tough-cookie";
 import { config } from "./config.js";
+import { v4 as uuidv4 } from "uuid";
 
 const api = got.extend({
   cookieJar: new CookieJar(),
@@ -20,6 +21,13 @@ const api = got.extend({
     limit: 2,
     methods: ["GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "TRACE"],
     statusCodes: [401, 403, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
+  },
+  hooks: {
+    beforeRequest: [
+      (options) => {
+        options.headers['x-correlation-id'] = uuidv4();
+      }
+    ]
   },
 });
 export function authByEmail() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toogoodtogo-watcher",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Node.js cli tool for monitoring your favorite TooGoodToGo businesses.",
   "type": "module",
   "exports": "./index.js",
@@ -34,6 +34,7 @@
     "rxjs": "^7.8.0",
     "telegraf": "^4.11.2",
     "tough-cookie": "^4.1.2",
+    "uuid": "^11.1.0",
     "yargs": "^17.7.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR addresses https://github.com/marklagendijk/node-toogoodtogo-watcher/issues/261.

I see 3 possible approaches:

1. Generation on UUID on startup and keep it until next restart, comparable to https://github.com/michelheusschen/tgtg/commit/aa5d75ced2f973c426f730b657cf514d46094370
2. Generate UUID on startup and update UUID in refreshToken()
3. Generate UUID for each request

I went for the last option and it works fine for me, but I am not sure whether this is the optimal approach/best practice.
Let me know if you would take another approach, I'd be happy to create another PR :)