### PR TITLE
Merge all entities to a single device

### DIFF
--- a/lib/notifications/homeassistant-mqtt.js
+++ b/lib/notifications/homeassistant-mqtt.js
@@ -17,24 +17,30 @@ export function notifyMqtt(messages) {
   const mqttClient = getMqttConnection();
 
   messages.forEach((message) => {
-    const deviceName = `TooGoodToGo ${message.name}`;
+    const entityName = `${message.name}`;
     const uniqueId = `toogoodtogo_${message.id}`;
 
     const stateTopic = `toogoodtogo-watcher/${uniqueId}`;
 
     if (!entitiesCache[uniqueId]) {
+      // Remove the previous configuration if it exists
+      // this is only needed for moving from multiple devices to a single device, but there is no way to detect that
+      mqttClient.publish(
+        `homeassistant/binary_sensor/toogoodtogo-watcher/${uniqueId}/config`,
+        ""
+      )
       // Publish the configuration for the binary sensor only once
       mqttClient.publish(
         `homeassistant/binary_sensor/toogoodtogo-watcher/${uniqueId}/config`,
         JSON.stringify({
-          name: deviceName,
+          name: entityName,
           device_class: "running",
           state_topic: stateTopic,
           json_attributes_topic: `${stateTopic}/attributes`,
           unique_id: uniqueId,
           device: {
-            identifiers: [uniqueId],
-            name: deviceName,
+            identifiers: ["toogoodtogo_watcher"],
+            name: "TooGoodToGo Watcher",
             model: "TGTG Availability",
             manufacturer: "node-toogoodtogo-watcher",
           },


### PR DESCRIPTION
Continuing on items as described in https://github.com/marklagendijk/node-toogoodtogo-watcher/issues/267.

   - All entities are now grouped in a single device.